### PR TITLE
Add external data ingestion pipelines and scenario toggles

### DIFF
--- a/external_data_ingestion.py
+++ b/external_data_ingestion.py
@@ -1,0 +1,123 @@
+"""External data ingestion pipelines for OpenPrescribing and OpenFDA.
+
+This module provides utility functions to retrieve prescribing analytics
+from the OpenPrescribing API and real‑world evidence (RWE) datasets from
+OpenFDA.  Retrieved data are mapped to the internal Digital Twin
+ontology and can be scheduled for periodic synchronisation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+import requests
+
+# API endpoints
+OPENPRESCRIBING_API = "https://openprescribing.net/api/1.0/spending_by_practice"
+OPENFDA_API = "https://api.fda.gov/drug/event.json"
+
+
+def fetch_openprescribing(ccg: str, measure: str) -> List[Dict[str, Any]]:
+    """Fetch prescribing analytics for a Clinical Commissioning Group.
+
+    Parameters
+    ----------
+    ccg: str
+        The CCG identifier (e.g. ``"10Q"``).
+    measure: str
+        Measure name such as ``"cost"`` or ``"quantity"``.
+    """
+
+    params = {"ccg": ccg, "measure": measure}
+    resp = requests.get(OPENPRESCRIBING_API, params=params, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_openfda(drug_name: str, limit: int = 1) -> Dict[str, Any]:
+    """Fetch adverse event reports for a drug from OpenFDA."""
+
+    params = {
+        "search": f"patient.drug.medicinalproduct:\"{drug_name}\"",
+        "limit": limit,
+    }
+    resp = requests.get(OPENFDA_API, params=params, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def map_prescribing_data(data: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    """Map OpenPrescribing data to the Digital Twin schema."""
+
+    items = [
+        {
+            "code": row.get("bnf_code"),
+            "quantity": row.get("quantity"),
+            "cost": row.get("actual_cost"),
+            "date": row.get("date"),
+        }
+        for row in data
+    ]
+    return {"source": "openprescribing", "items": items}
+
+
+def map_fda_data(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Map OpenFDA event data to the Digital Twin schema."""
+
+    reports = []
+    for result in data.get("results", []):
+        reactions = [
+            rx.get("reactionmeddrapt")
+            for rx in result.get("patient", {}).get("reaction", [])
+        ]
+        reports.append(
+            {
+                "safety_report_id": result.get("safetyreportid"),
+                "received_date": result.get("receivedate"),
+                "reactions": reactions,
+            }
+        )
+    return {"source": "openfda", "reports": reports}
+
+
+def _default_store(target: List[Dict[str, Any]], payload: Dict[str, Any]) -> None:
+    """Default callback to store synced payloads in a list."""
+
+    target.append(payload)
+
+
+def schedule_sync(
+    interval: timedelta,
+    fetch: Callable[..., Any],
+    mapper: Callable[[Any], Dict[str, Any]],
+    callback: Optional[Callable[[Dict[str, Any]], None]] = None,
+    *args: Any,
+    **kwargs: Any,
+) -> Callable[[], None]:
+    """Schedule periodic synchronisation.
+
+    Returns a function that cancels the scheduled task when called.
+    """
+
+    loop = asyncio.get_event_loop()
+    storage: List[Dict[str, Any]] = []
+
+    if callback is None:
+        callback = lambda payload: _default_store(storage, payload)
+
+    async def _runner() -> None:
+        while True:
+            data = fetch(*args, **kwargs)
+            mapped = mapper(data)
+            callback(mapped)
+            await asyncio.sleep(interval.total_seconds())
+
+    task = loop.create_task(_runner())
+
+    def cancel() -> None:
+        task.cancel()
+
+    return cancel
+

--- a/quantum_engine.py
+++ b/quantum_engine.py
@@ -1,5 +1,9 @@
 import numpy as np
-from qiskit import QuantumCircuit, transpile, Aer, execute
+from qiskit import QuantumCircuit, transpile
+try:  # Qiskit >= 0.25 separates Aer
+    from qiskit_aer import Aer
+except Exception:  # pragma: no cover - fallback for older versions
+    from qiskit import Aer
 
 class QuantumScenarioSimulator:
     def __init__(self, num_qubits=4):
@@ -18,7 +22,8 @@ class QuantumScenarioSimulator:
             qc.ry(param, i)
         qc.barrier()
         qc.measure(range(self.num_qubits), range(self.num_qubits))
-        job = execute(qc, self.backend, shots=1024)
+        compiled = transpile(qc, self.backend)
+        job = self.backend.run(compiled, shots=1024)
         result = job.result()
         counts = result.get_counts(qc)
         return counts

--- a/report_exporter.py
+++ b/report_exporter.py
@@ -1,0 +1,46 @@
+"""Utilities to export simulation results in FDA‑friendly formats."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict
+
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+
+def export_fda_report(data: Dict, base_path: str) -> Dict[str, str]:
+    """Export simulation results to JSON and PDF files.
+
+    Parameters
+    ----------
+    data: Dict
+        Simulation results already mapped to the Digital Twin ontology.
+    base_path: str
+        Path without extension where files will be written.
+
+    Returns
+    -------
+    Dict[str, str]
+        Mapping of format to the generated file path.
+    """
+
+    json_path = f"{base_path}.json"
+    pdf_path = f"{base_path}.pdf"
+
+    # Write JSON representation
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+    # Basic PDF rendering
+    c = canvas.Canvas(pdf_path, pagesize=letter)
+    text = c.beginText(40, 750)
+    text.textLine("FDA Simulation Report")
+    for key, value in data.items():
+        text.textLine(f"{key}: {value}")
+    c.drawText(text)
+    c.showPage()
+    c.save()
+
+    return {"json": json_path, "pdf": pdf_path}
+

--- a/scenario_ui.py
+++ b/scenario_ui.py
@@ -1,0 +1,39 @@
+"""Simple UI toggles for simulation scenario inputs."""
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class ScenarioToggle:
+    """Container tracking enabled scenario inputs."""
+
+    pricing: bool = True
+    utilization: bool = True
+    policy: bool = True
+
+    def toggle(self, key: str) -> None:
+        if hasattr(self, key):
+            setattr(self, key, not getattr(self, key))
+        else:
+            raise KeyError(f"Unknown scenario input: {key}")
+
+    def as_dict(self) -> Dict[str, bool]:
+        return {"pricing": self.pricing, "utilization": self.utilization, "policy": self.policy}
+
+
+def interactive_toggle(toggle: ScenarioToggle) -> ScenarioToggle:
+    """CLI helper to allow users to toggle inputs."""
+
+    print("Toggle scenario inputs (pricing, utilization, policy). Enter to finish.")
+    while True:
+        key = input("Input to toggle (or press enter to finish): ").strip().lower()
+        if not key:
+            break
+        try:
+            toggle.toggle(key)
+            print(f"{key} set to {getattr(toggle, key)}")
+        except KeyError as exc:
+            print(exc)
+    return toggle
+

--- a/test_external_data_ingestion.py
+++ b/test_external_data_ingestion.py
@@ -1,0 +1,37 @@
+import pytest
+
+from external_data_ingestion import map_prescribing_data, map_fda_data
+from scenario_ui import ScenarioToggle
+
+
+def test_map_prescribing_data():
+    sample = [
+        {"bnf_code": "0101010T0", "quantity": 10, "actual_cost": 2.5, "date": "2023-01-01"}
+    ]
+    mapped = map_prescribing_data(sample)
+    assert mapped["source"] == "openprescribing"
+    assert mapped["items"][0]["code"] == "0101010T0"
+
+
+def test_map_fda_data():
+    sample = {
+        "results": [
+            {
+                "safetyreportid": "1",
+                "receivedate": "20230101",
+                "patient": {"reaction": [{"reactionmeddrapt": "Headache"}]},
+            }
+        ]
+    }
+    mapped = map_fda_data(sample)
+    assert mapped["source"] == "openfda"
+    assert mapped["reports"][0]["reactions"] == ["Headache"]
+
+
+def test_toggle_scenario():
+    toggle = ScenarioToggle()
+    toggle.toggle("pricing")
+    assert toggle.pricing is False
+    toggle.toggle("pricing")
+    assert toggle.pricing is True
+


### PR DESCRIPTION
## Summary
- Add OpenPrescribing and OpenFDA ingestion pipelines with schema mapping and scheduled sync support
- Enable scenario input toggling and export of FDA-ready simulation reports
- Fix quantum engine to use modern Qiskit Aer backend

## Testing
- `pip install pydantic openai`
- `pip install qiskit qiskit-aer`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c48aed4d8c83289828996423886839